### PR TITLE
Set export-ignore for useless files and directories to optimize traffic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore
+/changelog.md export-ignore
+/README.md export-ignore
+/yii


### PR DESCRIPTION
Composer will ignore next files during installation. It will optimize traffic in future